### PR TITLE
SuperPoint builder

### DIFF
--- a/app/src/main/java/com/github/featuredetectandroid/utils/KeypointDetectionAlgorithm.kt
+++ b/app/src/main/java/com/github/featuredetectandroid/utils/KeypointDetectionAlgorithm.kt
@@ -16,10 +16,6 @@ enum class KeypointDetectionAlgorithm(val algorithmName: String) {
     companion object {
         val names = values().map { it.algorithmName }
 
-        /**
-         * SuperPoint, which needs a context during initialization,
-         * does not retain links to it, so no context leak needs to be handled.
-         */
         fun nameToFeatureDetector(
             context: Context,
             algorithmName: String,
@@ -29,7 +25,7 @@ enum class KeypointDetectionAlgorithm(val algorithmName: String) {
             SIFT.algorithmName -> Sift(width, height)
             SURF.algorithmName -> Surf(width, height)
             ORB.algorithmName -> Orb(width, height)
-            SUPERPOINT.algorithmName -> SuperPoint(context, width, height)
+            SUPERPOINT.algorithmName -> SuperPoint.Builder(context, width, height).build()
             else -> null
         }
     }

--- a/lib/src/main/java/com/github/featuredetectlib/learned/SuperPoint.kt
+++ b/lib/src/main/java/com/github/featuredetectlib/learned/SuperPoint.kt
@@ -6,6 +6,7 @@ import com.github.featuredetectlib.FeatureDetector
 import com.github.featuredetectlib.Keypoint
 import org.pytorch.IValue
 import org.pytorch.LiteModuleLoader
+import org.pytorch.Module
 import org.pytorch.Tensor
 import kotlin.math.pow
 
@@ -18,10 +19,12 @@ private const val DESCRIPTOR_SIZE = 256
  * Detects learned keypoints and their descriptors using
  * [SuperPoint](https://github.com/magicleap/SuperPointPretrainedNetwork) network.
  */
-class SuperPoint(context: Context, width: Int, height: Int) : FeatureDetector {
-    private val net = LiteModuleLoader.loadModuleFromAsset(context.assets, NETWORK_ASSET)
-    private val decoder = LiteModuleLoader.loadModuleFromAsset(context.assets, DECODER_ASSET)
-
+class SuperPoint private constructor(
+    private val net: Module,
+    private val decoder: Module,
+    width: Int,
+    height: Int,
+) : FeatureDetector {
     override var width = width
         set(value) {
             field = value
@@ -42,11 +45,12 @@ class SuperPoint(context: Context, width: Int, height: Int) : FeatureDetector {
 
     override fun detect(image: ByteArray): Pair<List<Keypoint>, List<Descriptor>> {
         val input = Tensor.fromBlob(rgbToGrayscale(image), longArrayOf(1, 1, longHeight, longWidth))
-        val output = net.forward(IValue.from(input)).toTuple()
-        val decoded = decoder.forward(output[0], output[1], wrappedHeight, wrappedWidth).toTuple()
+        val (encKeypoints, encDescriptors) = net.forward(IValue.from(input)).toTuple()
+        val (decKeypoints, decDescriptors) =
+            decoder.forward(encKeypoints, encDescriptors, wrappedHeight, wrappedWidth).toTuple()
 
-        val keypoints = keypointTensorToKeypointList(decoded[0].toTensor())
-        val descriptors = descriptorTensorToDescriptorList(decoded[1].toTensor())
+        val keypoints = keypointTensorToKeypointList(decKeypoints.toTensor())
+        val descriptors = descriptorTensorToDescriptorList(decDescriptors.toTensor())
 
         return keypoints to descriptors
     }
@@ -88,5 +92,40 @@ class SuperPoint(context: Context, width: Int, height: Int) : FeatureDetector {
                 }
             }
         return list
+    }
+
+    /**
+     * Builds [SuperPoint] from [Context].
+     *
+     * The Context is not retained in the resulting SuperPoint instance.
+     */
+    class Builder(
+        context: Context,
+        /**
+         * Initial value of [SuperPoint.width].
+         */
+        var width: Int = 0,
+        /**
+         * Initial value of [SuperPoint.height].
+         */
+        var height: Int = 0
+    ) {
+        private val net = LiteModuleLoader.loadModuleFromAsset(context.assets, NETWORK_ASSET)
+        private val decoder = LiteModuleLoader.loadModuleFromAsset(context.assets, DECODER_ASSET)
+
+        /**
+         * Sets the initial value of [SuperPoint.width].
+         */
+        fun width(value: Int) = apply { width = value }
+
+        /**
+         * Sets the initial value of [SuperPoint.height].
+         */
+        fun height(value: Int) = apply { height = value }
+
+        /**
+         * Builds a [SuperPoint] instance.
+         */
+        fun build() = SuperPoint(net, decoder, width, height)
     }
 }

--- a/lib/src/main/java/com/github/featuredetectlib/traditional/NativeDetectorWrapper.kt
+++ b/lib/src/main/java/com/github/featuredetectlib/traditional/NativeDetectorWrapper.kt
@@ -22,7 +22,6 @@ internal class NativeDetectorWrapper(private val detector: NativeDetector) : Fea
 
     override fun detect(image: ByteArray): Pair<List<Keypoint>, List<Descriptor>> {
         val output = detector.detect(image)
-        // TODO: try to convert concurrently with async - await
         val keypoints = output.keypoints.map { NativeKeypointWrapper(it) }
         val descriptors = output.descriptors.map { descriptor -> descriptor.map { it.toFloat() } }
         return keypoints to descriptors


### PR DESCRIPTION
Changes the way `SuperPoint` is build from using its constructor to using a builder. This is needed to explicitly show that `Context` should only be used during `SuperPoint` instantiation without retaining it in the instance itself.