### PR TITLE
Fix Scapix configuration error

### DIFF
--- a/lib/src/main/cpp/CMakeLists.txt
+++ b/lib/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 project(featurelib)
 
 option(BUILD_EXAMPLES "Build examples" OFF)


### PR DESCRIPTION
After `scapix_fix_sources` was removed from `examples` CMake file `cmake_minimum_required` had to be increased to `3.20` to avoid Scapix configuration errors