### PR TITLE
Remove native duplicated code

### DIFF
--- a/lib/src/main/cpp/include/feature_detector.h
+++ b/lib/src/main/cpp/include/feature_detector.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cstdint>
 #include <opencv2/core.hpp>
+#include <opencv2/features2d.hpp>
 #include "stripped_keypoint.h"
 #include "detection_result.h"
 
@@ -43,9 +44,7 @@ namespace featurelib {
 
 class FeatureDetector : public internal::base_object<FeatureDetector> {
  public:
-  FeatureDetector(int width, int height);
-
-  virtual std::shared_ptr<DetectionResult> detect(const std::vector<std::uint8_t> &input_vector) const = 0;
+  std::shared_ptr<DetectionResult> detect(const std::vector<std::uint8_t> &pixel_data) const;
 
   int getHeight() const;
 
@@ -56,8 +55,12 @@ class FeatureDetector : public internal::base_object<FeatureDetector> {
   void setWidth(int value);
 
  protected:
+  FeatureDetector(int width, int height, cv::Ptr<cv::Feature2D> detector);
+
+ private:
   int width_;
   int height_;
+  cv::Ptr<cv::Feature2D> detector_;
   cv::Mat mask_ = cv::Mat(height_, width_, CV_8U, cv::Scalar(255));  // Required to pick image region for detection
 };
 

--- a/lib/src/main/cpp/include/orb_detector.h
+++ b/lib/src/main/cpp/include/orb_detector.h
@@ -1,9 +1,6 @@
 #ifndef LIB_SRC_MAIN_CPP_INCLUDE_ORB_DETECTOR_H_
 #define LIB_SRC_MAIN_CPP_INCLUDE_ORB_DETECTOR_H_
 
-#include <memory>
-#include <vector>
-#include <opencv2/features2d.hpp>
 #include "feature_detector.h"
 
 namespace featurelib {
@@ -11,11 +8,6 @@ namespace featurelib {
 class OrbDetector : public FeatureDetector {
  public:
   OrbDetector(int width, int height);
-
-  std::shared_ptr<DetectionResult> detect(const std::vector<std::uint8_t> &input) const override;
-
- private:
-  cv::Ptr<cv::Feature2D> orb_ = cv::ORB::create();
 };
 
 }  // namespace featurelib

--- a/lib/src/main/cpp/include/sift_detector.h
+++ b/lib/src/main/cpp/include/sift_detector.h
@@ -1,9 +1,6 @@
 #ifndef LIB_SRC_MAIN_CPP_INCLUDE_SIFT_DETECTOR_H_
 #define LIB_SRC_MAIN_CPP_INCLUDE_SIFT_DETECTOR_H_
 
-#include <memory>
-#include <vector>
-#include <opencv2/features2d.hpp>
 #include "feature_detector.h"
 
 namespace featurelib {
@@ -11,11 +8,6 @@ namespace featurelib {
 class SiftDetector : public FeatureDetector {
  public:
   SiftDetector(int width, int height);
-
-  std::shared_ptr<DetectionResult> detect(const std::vector<std::uint8_t> &input) const override;
-
- private:
-  cv::Ptr<cv::Feature2D> sift_ = cv::SIFT::create();
 };
 
 }  // namespace featurelib

--- a/lib/src/main/cpp/include/surf_detector.h
+++ b/lib/src/main/cpp/include/surf_detector.h
@@ -1,9 +1,6 @@
 #ifndef LIB_SRC_MAIN_CPP_INCLUDE_SURF_DETECTOR_H_
 #define LIB_SRC_MAIN_CPP_INCLUDE_SURF_DETECTOR_H_
 
-#include <memory>
-#include <vector>
-#include <opencv2/xfeatures2d.hpp>
 #include "feature_detector.h"
 
 namespace featurelib {
@@ -11,11 +8,6 @@ namespace featurelib {
 class SurfDetector : public FeatureDetector {
  public:
   SurfDetector(int width, int height);
-
-  std::shared_ptr<DetectionResult> detect(const std::vector<std::uint8_t> &input) const override;
-
- private:
-  cv::Ptr<cv::Feature2D> surf_ = cv::xfeatures2d::SURF::create();
 };
 
 }  // namespace featurelib

--- a/lib/src/main/cpp/src/conversions.cpp
+++ b/lib/src/main/cpp/src/conversions.cpp
@@ -21,11 +21,10 @@ std::vector<std::vector<uint8_t>> matTo2DVector(const cv::Mat &mat) {
   return result;
 }
 
-std::vector<std::shared_ptr<featurelib::StrippedKeypoint>> convertToStructure(
-    const std::vector<cv::KeyPoint> &key_points) {
+std::vector<std::shared_ptr<featurelib::StrippedKeypoint>> stripKeypoints(const std::vector<cv::KeyPoint> &keypoints) {
   std::vector<std::shared_ptr<featurelib::StrippedKeypoint>> output;
-  output.reserve(key_points.size());
-  for (auto &kp : key_points) {
+  output.reserve(keypoints.size());
+  for (auto &kp : keypoints) {
     output.emplace_back(std::make_shared<featurelib::StrippedKeypoint>(kp.pt.x,
                                                                        kp.pt.y,
                                                                        kp.angle,

--- a/lib/src/main/cpp/src/conversions.h
+++ b/lib/src/main/cpp/src/conversions.h
@@ -10,7 +10,6 @@ cv::Mat vectorToMat(const std::vector<std::uint8_t> &input_vector, int height, i
 
 std::vector<std::vector<uint8_t>> matTo2DVector(const cv::Mat &mat);
 
-std::vector<std::shared_ptr<featurelib::StrippedKeypoint>> convertToStructure(
-    const std::vector<cv::KeyPoint> &key_points);
+std::vector<std::shared_ptr<featurelib::StrippedKeypoint>> stripKeypoints(const std::vector<cv::KeyPoint> &keypoints);
 
 #endif  // LIB_SRC_MAIN_CPP_SRC_CONVERSIONS_H_

--- a/lib/src/main/cpp/src/feature_detector.cpp
+++ b/lib/src/main/cpp/src/feature_detector.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<DetectionResult> FeatureDetector::detect(const std::vector<std::
 
   detector_->detectAndCompute(image, mask_, cv_keypoints, cv_descriptors);
 
-  auto keypoints = convertToStructure(cv_keypoints);
+  auto keypoints = stripKeypoints(cv_keypoints);
   auto descriptors = matTo2DVector(cv_descriptors);
 
   return std::make_shared<DetectionResult>(keypoints, descriptors);

--- a/lib/src/main/cpp/src/feature_detector.cpp
+++ b/lib/src/main/cpp/src/feature_detector.cpp
@@ -1,8 +1,33 @@
+#include <utility>
+#include <opencv2/imgproc.hpp>
+#include "conversions.h"
 #include "feature_detector.h"
 
 namespace featurelib {
 
-FeatureDetector::FeatureDetector(int width, int height) : width_(width), height_(height) {}
+FeatureDetector::FeatureDetector(int width, int height, cv::Ptr<cv::Feature2D> detector)
+    : width_(width), height_(height), detector_(std::move(detector)) {}
+
+std::shared_ptr<DetectionResult> FeatureDetector::detect(const std::vector<std::uint8_t> &pixel_data) const {
+  if (height_ <= 0 || width_ <= 0) {  // cv::cvtColor throws on empty input
+    return std::make_shared<DetectionResult>(
+        std::vector<std::shared_ptr<StrippedKeypoint>>(),
+        std::vector<std::vector<uint8_t>>());
+  }
+
+  auto image = vectorToMat(pixel_data, height_, width_);
+  cv::cvtColor(image, image, cv::COLOR_RGB2GRAY);
+
+  std::vector<cv::KeyPoint> cv_keypoints;
+  cv::Mat cv_descriptors;
+
+  detector_->detectAndCompute(image, mask_, cv_keypoints, cv_descriptors);
+
+  auto keypoints = convertToStructure(cv_keypoints);
+  auto descriptors = matTo2DVector(cv_descriptors);
+
+  return std::make_shared<DetectionResult>(keypoints, descriptors);
+}
 
 int FeatureDetector::getHeight() const {
   return height_;

--- a/lib/src/main/cpp/src/orb_detector.cpp
+++ b/lib/src/main/cpp/src/orb_detector.cpp
@@ -1,31 +1,8 @@
-#include <opencv2/imgproc.hpp>
-#include "conversions.h"
+#include <opencv2/features2d.hpp>
 #include "orb_detector.h"
 
 namespace featurelib {
 
-OrbDetector::OrbDetector(int width, int height) : FeatureDetector(width, height) {}
-
-std::shared_ptr<featurelib::DetectionResult>
-OrbDetector::detect(const std::vector<std::uint8_t> &input) const {
-  if (height_ <= 0 || width_ <= 0) {  // cv::cvtColor throws on empty input
-    return std::make_shared<DetectionResult>(
-        std::vector<std::shared_ptr<StrippedKeypoint>>(),
-        std::vector<std::vector<uint8_t>>());
-  }
-
-  auto image = vectorToMat(input, height_, width_);
-  cv::cvtColor(image, image, cv::COLOR_RGB2GRAY);
-
-  std::vector<cv::KeyPoint> orb_keypoints;
-  cv::Mat orb_descriptors;
-
-  orb_->detectAndCompute(image, mask_, orb_keypoints, orb_descriptors);
-
-  auto keypoints = convertToStructure(orb_keypoints);
-  auto descriptors = matTo2DVector(orb_descriptors);
-
-  return std::make_shared<DetectionResult>(keypoints, descriptors);
-}
+OrbDetector::OrbDetector(int width, int height) : FeatureDetector(width, height, cv::ORB::create()) {}
 
 }  // namespace featurelib

--- a/lib/src/main/cpp/src/sift_detector.cpp
+++ b/lib/src/main/cpp/src/sift_detector.cpp
@@ -1,30 +1,8 @@
-#include <opencv2/imgproc.hpp>
-#include "conversions.h"
+#include <opencv2/features2d.hpp>
 #include "sift_detector.h"
 
 namespace featurelib {
 
-SiftDetector::SiftDetector(int width, int height) : FeatureDetector(width, height) {}
-
-std::shared_ptr<featurelib::DetectionResult> SiftDetector::detect(const std::vector<std::uint8_t> &input) const {
-  if (height_ <= 0 || width_ <= 0) {  // cv::cvtColor throws on empty input
-    return std::make_shared<DetectionResult>(
-            std::vector<std::shared_ptr<StrippedKeypoint>>(),
-            std::vector<std::vector<uint8_t>>());
-  }
-
-  auto image = vectorToMat(input, height_, width_);
-  cv::cvtColor(image, image, cv::COLOR_RGB2GRAY);
-
-  std::vector<cv::KeyPoint> sift_keypoints;
-  cv::Mat sift_descriptors;
-
-  sift_->detectAndCompute(image, mask_, sift_keypoints, sift_descriptors);
-
-  auto keypoints = convertToStructure(sift_keypoints);
-  auto descriptors = matTo2DVector(sift_descriptors);
-
-  return std::make_shared<DetectionResult>(keypoints, descriptors);
-}
+SiftDetector::SiftDetector(int width, int height) : FeatureDetector(width, height, cv::SIFT::create()) {}
 
 }  // namespace featurelib

--- a/lib/src/main/cpp/src/surf_detector.cpp
+++ b/lib/src/main/cpp/src/surf_detector.cpp
@@ -1,30 +1,8 @@
-#include <opencv2/imgproc.hpp>
-#include "conversions.h"
+#include <opencv2/xfeatures2d.hpp>
 #include "surf_detector.h"
 
 namespace featurelib {
 
-SurfDetector::SurfDetector(int width, int height) : FeatureDetector(width, height) {}
-
-std::shared_ptr<featurelib::DetectionResult> SurfDetector::detect(const std::vector<std::uint8_t> &input) const {
-  if (height_ <= 0 || width_ <= 0) {  // cv::cvtColor throws on empty input
-    return std::make_shared<DetectionResult>(
-            std::vector<std::shared_ptr<StrippedKeypoint>>(),
-            std::vector<std::vector<uint8_t>>());
-  }
-
-  auto image = vectorToMat(input, height_, width_);
-  cv::cvtColor(image, image, cv::COLOR_RGB2GRAY);
-
-  std::vector<cv::KeyPoint> surf_keypoints;
-  cv::Mat surf_descriptors;
-
-  surf_->detectAndCompute(image, mask_, surf_keypoints, surf_descriptors);
-
-  auto keypoints = convertToStructure(surf_keypoints);
-  auto descriptors = matTo2DVector(surf_descriptors);
-
-  return std::make_shared<DetectionResult>(keypoints, descriptors);
-}
+SurfDetector::SurfDetector(int width, int height) : FeatureDetector(width, height, cv::xfeatures2d::SURF::create()) {}
 
 }  // namespace featurelib


### PR DESCRIPTION
Extracts common detection code from `Sift`, `Surf`, and `Orb` classes to `FeatureDetector`