### PR TITLE
Add Android linting to CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,24 @@ defaults:
     shell: bash
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run detekt
+        run: ./gradlew detekt
+
   build:
     runs-on: ubuntu-latest
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'io.gitlab.arturbosch.detekt'
 }
 
 android {
@@ -59,4 +60,10 @@ dependencies {
     implementation 'com.google.accompanist:accompanist-systemuicontroller:0.23.1'
 
     implementation project(':lib')
+}
+
+detekt {
+    config = files "$rootDir/config/detekt/detekt.yml"
+    buildUponDefaultConfig = true
+    ignoredBuildTypes = ['release']
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     implementation 'com.google.accompanist:accompanist-systemuicontroller:0.23.1'
 
     implementation project(':lib')
+
+    detektPlugins 'io.gitlab.arturbosch.detekt:detekt-formatting:1.21.0'
 }
 
 detekt {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,3 +69,8 @@ detekt {
     buildUponDefaultConfig = true
     ignoredBuildTypes = ['release']
 }
+
+// Exclude detekt from check task to make building independent from linting
+tasks.named 'check' configure {
+    dependsOn.removeIf { it.name == 'detekt' }
+}

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,4 @@
+naming:
+  FunctionNaming:
+    ignoreAnnotated:
+      - 'Composable'

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -2,3 +2,13 @@ naming:
   FunctionNaming:
     ignoreAnnotated:
       - 'Composable'
+  MatchingDeclarationName:
+    active: false # Overlapped by formatting>Filename
+
+style:
+  NewLineAtEndOfFile:
+    active: false # Overlapped by formatting>FinalNewline
+  MaxLineLength:
+    active: false # Overlapped by formatting>MaximumLineLength
+  ModifierOrder:
+    active: false # Overlapped by formatting>ModifierOrdering

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -74,3 +74,8 @@ detekt {
     buildUponDefaultConfig = true
     ignoredBuildTypes = ['release']
 }
+
+// Exclude detekt from check task to make building independent from linting
+tasks.named 'check' configure {
+    dependsOn.removeIf { it.name == 'detekt' }
+}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -65,6 +65,8 @@ dependencies {
 
     implementation 'org.pytorch:pytorch_android_lite:1.12.2'
     implementation 'org.pytorch:pytorch_android_torchvision_lite:1.12.2'
+
+    detektPlugins 'io.gitlab.arturbosch.detekt:detekt-formatting:1.21.0'
 }
 
 detekt {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -53,8 +53,8 @@ android {
     // Without this Kotlin code may start trying to compile before JNI interface is generated
     libraryVariants.all { variant ->
         def variantName = variant.name.capitalize()
-        def nativeBuild = tasks.getByName("externalNativeBuild$variantName")
-        def compileKotlin = tasks.getByName("compile${variantName}Kotlin")
+        def nativeBuild = tasks.getByName "externalNativeBuild$variantName"
+        def compileKotlin = tasks.getByName "compile${variantName}Kotlin"
 
         compileKotlin.dependsOn nativeBuild
     }
@@ -67,11 +67,8 @@ dependencies {
     implementation 'org.pytorch:pytorch_android_torchvision_lite:1.12.2'
 }
 
-tasks.named('detekt').configure {
-    reports { // Only HTML report is generated
-        xml.required.set(false)
-        txt.required.set(false)
-        sarif.required.set(false)
-        md.required.set(false)
-    }
+detekt {
+    config = files "$rootDir/config/detekt/detekt.yml"
+    buildUponDefaultConfig = true
+    ignoredBuildTypes = ['release']
 }


### PR DESCRIPTION
Configures `detekt` with `ktlint` included and adds it into Android GitHub Actions workflow. Fully closes #20.

_Note_: the workflow fails because the current Android code doesn't pass linting.