### PR TITLE
Camera resolution selection

### DIFF
--- a/app/src/main/java/com/github/kpdandroid/MainActivity.kt
+++ b/app/src/main/java/com/github/kpdandroid/MainActivity.kt
@@ -4,39 +4,41 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.Log
+import android.util.Size
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.ImageAnalysis
-import androidx.camera.core.ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888
-import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.material.icons.filled.Build
 import androidx.core.content.ContextCompat
 import com.github.kpdandroid.ui.AppLayout
+import com.github.kpdandroid.ui.BottomMenu
+import com.github.kpdandroid.ui.BottomMenuItem
 import com.github.kpdandroid.ui.SnapshotViewModel
 import com.github.kpdandroid.ui.theme.KeypointDetectAppTheme
+import com.github.kpdandroid.utils.CameraHandler
 import com.github.kpdandroid.utils.KeypointDetectionAlgorithm
-import com.github.kpdandroid.utils.PhotoAnalyzer
 import com.github.kpdandroid.utils.PreferencesManager
-import java.util.concurrent.Executors
+import com.github.kpdandroid.utils.SnapshotAnalyzer
 
 private const val TAG = "MainActivity"
 
 class MainActivity : ComponentActivity() {
     private val snapshotViewModel by viewModels<SnapshotViewModel>()
     private lateinit var preferencesManager: PreferencesManager
-    private val cameraExecutor = Executors.newSingleThreadExecutor()
-    private var isAnalyzing = false
+    private lateinit var cameraHandler: CameraHandler
 
     private val cameraPermissionRequest =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
             if (granted) {
                 Toast.makeText(this, "Permissions granted.", Toast.LENGTH_SHORT).show()
                 Log.d(TAG, "Permission was granted successfully.")
-                startCameraAnalysis()
+                startCameraAnalysisIfNeeded()
             } else {
                 Toast.makeText(this, "Permissions not granted.", Toast.LENGTH_SHORT).show()
                 Log.d(TAG, "Permission was NOT granted.")
@@ -47,6 +49,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         preferencesManager = (application as KeypointDetectApp).preferencesManager
+        cameraHandler = CameraHandler(this, SnapshotAnalyzer(snapshotViewModel))
 
         snapshotViewModel.keypointDetector = KeypointDetectionAlgorithm.constructKeypointDetector(
             algorithmName = preferencesManager.selectedAlgorithmName,
@@ -63,16 +66,47 @@ class MainActivity : ComponentActivity() {
                     image = snapshotViewModel.paintedSnapshot,
                     calcTimeMs = snapshotViewModel.calcTimeMs,
                     isCameraPermissionGranted = isCameraPermissionGranted(),
-                    initialAlgorithmName = preferencesManager.selectedAlgorithmName,
-                    onAlgorithmSelected = { algorithmName ->
-                        preferencesManager.selectedAlgorithmName = algorithmName
-                        snapshotViewModel.keypointDetector =
-                            KeypointDetectionAlgorithm.constructKeypointDetector(
-                                algorithmName = algorithmName,
-                                context = this,
-                                width = snapshotViewModel.keypointDetector?.width ?: 0,
-                                height = snapshotViewModel.keypointDetector?.height ?: 0
+                    bottomMenu = {
+                        BottomMenu {
+                            BottomMenuItem(
+                                options = KeypointDetectionAlgorithm.names,
+                                selectedOption = preferencesManager.selectedAlgorithmName,
+                                onSelected = { algorithmName ->
+                                    preferencesManager.selectedAlgorithmName = algorithmName
+                                    snapshotViewModel.keypointDetector =
+                                        KeypointDetectionAlgorithm.constructKeypointDetector(
+                                            algorithmName = algorithmName,
+                                            context = this@MainActivity,
+                                            width = snapshotViewModel.keypointDetector?.width ?: 0,
+                                            height = snapshotViewModel.keypointDetector?.height ?: 0
+                                        )
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.Build,
+                                        contentDescription = "Detection algorithm"
+                                    )
+                                }
                             )
+
+                            BottomMenuItem(
+                                options = cameraHandler.supportedResolutions.map { it.toString() },
+                                selectedOption = preferencesManager.selectedResolution?.toString()
+                                    ?: "Pick resolution",
+                                onSelected = { sizeString ->
+                                    cameraHandler.startImageAnalysis(
+                                        targetResolution = Size.parseSize(sizeString),
+                                        callback = preferencesManager::selectedResolution::set
+                                    )
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.AccountBox,
+                                        contentDescription = "Camera resolution"
+                                    )
+                                }
+                            )
+                        }
                     }
                 )
             }
@@ -85,15 +119,19 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
-        cameraExecutor.shutdown()
+        cameraHandler.shutdown()
         super.onDestroy()
     }
 
     private fun startCameraAnalysisIfNeeded() {
-        if (isAnalyzing) return
+        if (cameraHandler.isAnalyzing) return
 
         when {
-            isCameraPermissionGranted() -> startCameraAnalysis()
+            isCameraPermissionGranted() ->
+                cameraHandler.startImageAnalysis(
+                    targetResolution = preferencesManager.selectedResolution,
+                    callback = preferencesManager::selectedResolution::set
+                )
             shouldRationalize() -> {
                 Toast.makeText(
                     this,
@@ -113,31 +151,4 @@ class MainActivity : ComponentActivity() {
     private fun shouldRationalize() =
         (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) &&
             shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)
-
-    private fun startCameraAnalysis() {
-        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
-
-        cameraProviderFuture.addListener({
-            val cameraProvider = cameraProviderFuture.get()
-
-            val imageAnalyzer = ImageAnalysis.Builder()
-                .setOutputImageFormat(OUTPUT_IMAGE_FORMAT_RGBA_8888)
-                .setOutputImageRotationEnabled(true)
-                .build()
-                .apply { setAnalyzer(cameraExecutor, PhotoAnalyzer(snapshotViewModel)) }
-
-            val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
-
-            cameraProvider.unbindAll() // Just in case
-
-            try {
-                cameraProvider.bindToLifecycle(this, cameraSelector, imageAnalyzer)
-                isAnalyzing = true
-            } catch (illegalState: IllegalStateException) {
-                Log.e(TAG, "Use case binding failed: ", illegalState)
-            } catch (illegalArgument: IllegalArgumentException) {
-                Log.e(TAG, "Use case binding failed: ", illegalArgument)
-            }
-        }, ContextCompat.getMainExecutor(this))
-    }
 }

--- a/app/src/main/java/com/github/kpdandroid/MainActivity.kt
+++ b/app/src/main/java/com/github/kpdandroid/MainActivity.kt
@@ -58,6 +58,10 @@ class MainActivity : ComponentActivity() {
             height = snapshotViewModel.keypointDetector?.height ?: 0
         )
 
+        initLayout()
+    }
+
+    private fun initLayout() {
         setContent {
             KeypointDetectAppTheme {
                 snapshotViewModel.painter.pointColor = MaterialTheme.colors.primary
@@ -118,11 +122,6 @@ class MainActivity : ComponentActivity() {
         if (isTopResumedActivity) startCameraAnalysisIfNeeded()
     }
 
-    override fun onDestroy() {
-        cameraHandler.shutdown()
-        super.onDestroy()
-    }
-
     private fun startCameraAnalysisIfNeeded() {
         if (cameraHandler.isAnalyzing) return
 
@@ -151,4 +150,9 @@ class MainActivity : ComponentActivity() {
     private fun shouldRationalize() =
         (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) &&
             shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)
+
+    override fun onDestroy() {
+        cameraHandler.shutdown()
+        super.onDestroy()
+    }
 }

--- a/app/src/main/java/com/github/kpdandroid/ui/AppLayout.kt
+++ b/app/src/main/java/com/github/kpdandroid/ui/AppLayout.kt
@@ -4,33 +4,25 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.BottomAppBar
-import androidx.compose.material.Icon
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.unit.dp
-import com.github.kpdandroid.utils.KeypointDetectionAlgorithm
 
 @Composable
 fun AppLayout(
     image: ImageBitmap?,
     calcTimeMs: Long?,
     isCameraPermissionGranted: Boolean,
-    initialAlgorithmName: String,
-    onAlgorithmSelected: (String) -> Unit
+    bottomMenu: @Composable () -> Unit
 ) {
     Scaffold(
-        bottomBar = { BottomMenu(initialAlgorithmName, onAlgorithmSelected) },
+        bottomBar = bottomMenu,
         modifier = Modifier.fillMaxSize()
     ) { paddingValues ->
         if (!isCameraPermissionGranted) {
@@ -69,29 +61,6 @@ fun AppLayout(
                     modifier = Modifier.padding(30.dp)
                 )
             }
-        }
-    }
-}
-
-@Composable
-private fun BottomMenu(initialAlgorithmName: String, onAlgorithmSelected: (String) -> Unit) {
-    BottomAppBar {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceAround,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            BottomMenuItem(
-                options = KeypointDetectionAlgorithm.names,
-                initialOption = initialAlgorithmName,
-                onSelected = onAlgorithmSelected,
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.Build,
-                        contentDescription = "Detection algorithm"
-                    )
-                }
-            )
         }
     }
 }

--- a/app/src/main/java/com/github/kpdandroid/ui/BottomMenu.kt
+++ b/app/src/main/java/com/github/kpdandroid/ui/BottomMenu.kt
@@ -1,6 +1,10 @@
 package com.github.kpdandroid.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.BottomAppBar
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ExposedDropdownMenuBox
@@ -13,17 +17,29 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun BottomMenu(items: @Composable RowScope.() -> Unit) {
+    BottomAppBar {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceAround,
+            verticalAlignment = Alignment.CenterVertically,
+            content = items
+        )
+    }
+}
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun BottomMenuItem(
     options: List<String>,
-    initialOption: String,
+    selectedOption: String,
     onSelected: (String) -> Unit,
     leadingIcon: (@Composable () -> Unit)? = null
 ) {
     var expanded by remember { mutableStateOf(false) }
-    var selectedOption by remember { mutableStateOf(initialOption) }
 
     ExposedDropdownMenuBox(
         expanded = expanded,
@@ -48,7 +64,6 @@ fun BottomMenuItem(
                 DropdownMenuItem(
                     onClick = {
                         onSelected(option)
-                        selectedOption = option
                         expanded = false
                     }
                 ) {

--- a/app/src/main/java/com/github/kpdandroid/ui/SnapshotPainter.kt
+++ b/app/src/main/java/com/github/kpdandroid/ui/SnapshotPainter.kt
@@ -24,7 +24,7 @@ class SnapshotPainter(pointColor: Color = Color.Blue, pointWidth: Float = 10f) {
             pointPaint.strokeWidth = value
         }
 
-    fun paint(snapshot: ImageBitmap, points: List<Offset>) {
+    fun draw(snapshot: ImageBitmap, points: List<Offset>) {
         Canvas(snapshot).drawPoints(
             pointMode = PointMode.Points,
             points = points,

--- a/app/src/main/java/com/github/kpdandroid/ui/SnapshotViewModel.kt
+++ b/app/src/main/java/com/github/kpdandroid/ui/SnapshotViewModel.kt
@@ -21,7 +21,7 @@ class SnapshotViewModel : ViewModel() {
     val painter = SnapshotPainter()
 
     fun provideSnapshot(snapshot: Bitmap, keypoints: List<Offset>, calcTimeMs: Long) {
-        paintedSnapshot = snapshot.asImageBitmap().also { painter.paint(it, keypoints) }
-        this.calcTimeMs = if (keypointDetector != null) calcTimeMs else null
+        paintedSnapshot = snapshot.asImageBitmap().also { painter.draw(it, keypoints) }
+        this.calcTimeMs = keypointDetector?.run { calcTimeMs }
     }
 }

--- a/app/src/main/java/com/github/kpdandroid/utils/CameraHandler.kt
+++ b/app/src/main/java/com/github/kpdandroid/utils/CameraHandler.kt
@@ -148,7 +148,7 @@ class CameraHandler(
             resolutions.forEachIndexed { i, size -> resolutions[i] = size.flipped() }
         }
 
-        return resolutions.sortedBy { it.width }.apply {
+        return resolutions.sortedWith(compareBy<Size> { it.width }.thenBy { it.height }).apply {
             Log.i(TAG, "Supported resolutions: ${joinToString(", ")}.")
         }
     }

--- a/app/src/main/java/com/github/kpdandroid/utils/CameraHandler.kt
+++ b/app/src/main/java/com/github/kpdandroid/utils/CameraHandler.kt
@@ -1,0 +1,203 @@
+package com.github.kpdandroid.utils
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.ImageFormat
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.os.Build
+import android.util.Log
+import android.util.Size
+import android.view.Surface
+import android.view.WindowManager
+import androidx.camera.camera2.interop.Camera2CameraInfo
+import androidx.camera.core.Camera
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.app.ComponentActivity
+import androidx.core.content.ContextCompat
+import java.util.concurrent.Executors
+import kotlin.math.abs
+
+private const val TAG = "CameraHandler"
+
+// JPEG is always supported and seems to give the right resolutions for CameraX
+private const val IMAGE_FORMAT_CAMERA2 = ImageFormat.JPEG
+
+// Convenient to convert to RGB and Bitmap
+private const val IMAGE_FORMAT_CAMERAX = ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888
+
+private const val DEFAULT_SCREEN_ROTATION = 0
+private const val ROTATION_SAVING_STEP = 180
+
+class CameraHandler(
+    private val activity: ComponentActivity,
+    var analyzer: SnapshotAnalyzer,
+    cameraSelector: CameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+) {
+    private val cameraManager = activity.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+    private val cameraProviderFuture = ProcessCameraProvider.getInstance(activity)
+    private val cameraExecutor = Executors.newSingleThreadExecutor()
+    private val screenRotation = extractScreenRotation()
+    var cameraSelector = cameraSelector
+        set(value) {
+            supportedResolutions = emptyList()
+            extractSupportedResolutions()
+            field = value
+        }
+
+    var isAnalyzing = false // TODO: account for concurrent modification
+        private set
+    var supportedResolutions: List<Size> = emptyList()
+
+    init {
+        extractSupportedResolutions()
+    }
+
+    private fun extractScreenRotation(): Int {
+        val display = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.display
+        } else {
+            (activity.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+        }
+        if (display == null) {
+            Log.w(TAG, "Cannot get current display, assuming rotation is $DEFAULT_SCREEN_ROTATION.")
+            return DEFAULT_SCREEN_ROTATION
+        }
+        return when (display.rotation) {
+            Surface.ROTATION_0 -> 0
+            Surface.ROTATION_90 -> 90
+            Surface.ROTATION_180 -> 180
+            Surface.ROTATION_270 -> 270
+            else -> { // Should not happen
+                Log.wtf(TAG, "Unknown display rotation, assuming $DEFAULT_SCREEN_ROTATION.")
+                DEFAULT_SCREEN_ROTATION
+            }
+        }
+    }
+
+    private fun extractSupportedResolutions() {
+        ProcessCameraProvider.getInstance(activity).addListener({
+            Log.d(TAG, "Retrieving supported resolutions.")
+
+            val cameraProvider = cameraProviderFuture.get()
+
+            val camera = try {
+                cameraProvider.bindToLifecycle(activity, cameraSelector)
+            } catch (e: IllegalStateException) {
+                Log.e(TAG, "Camera binding failed", e)
+                return@addListener
+            } catch (e: IllegalArgumentException) {
+                Log.e(TAG, "Camera binding failed", e)
+                return@addListener
+            }
+
+            supportedResolutions = camera.getSupportedResolutions()
+        }, ContextCompat.getMainExecutor(activity))
+    }
+
+    @SuppressLint("UnsafeOptInUsageError")
+    private fun Camera.getSupportedResolutions(): List<Size> {
+        // Get camera configs
+        val cameraId = Camera2CameraInfo.from(cameraInfo).cameraId
+        val characteristics = cameraManager.getCameraCharacteristics(cameraId)
+        val configs = characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
+            ?: run { // Should not happen
+                Log.wtf(TAG, "Failed to retrieve configs of $this.")
+                return emptyList()
+            }
+
+        // Check format is supported
+        if (!configs.isOutputSupportedFor(IMAGE_FORMAT_CAMERA2)) {
+            Log.e(
+                TAG,
+                "Selected format $IMAGE_FORMAT_CAMERA2 is unsupported. " +
+                    "Supported formats: ${configs.outputFormats.joinToString(", ")}."
+            )
+            return emptyList()
+        }
+
+        // Get resolutions
+        val resolutions = configs.getOutputSizes(IMAGE_FORMAT_CAMERA2)
+
+        // Rotate resolutions if needed
+        Log.d(
+            TAG,
+            "Current rotations: " +
+                "screen -- $screenRotation, " +
+                "sensor -- ${cameraInfo.sensorRotationDegrees}."
+        )
+        if (abs(screenRotation - cameraInfo.sensorRotationDegrees) % ROTATION_SAVING_STEP != 0) {
+            Log.i(TAG, "Rotating resolutions.")
+            resolutions.forEachIndexed { i, size -> resolutions[i] = size.flipped() }
+        }
+
+        return resolutions.sortedBy { it.width }.apply {
+            Log.i(TAG, "Supported resolutions: ${joinToString(", ")}.")
+        }
+    }
+
+    private fun Size.flipped() = Size(height, width)
+
+    fun startImageAnalysis(targetResolution: Size?, callback: (realResolution: Size?) -> Unit) {
+        Log.i(TAG, "Starting image analysis targeting $targetResolution.")
+
+        ProcessCameraProvider.getInstance(activity).addListener({
+            val cameraProvider = cameraProviderFuture.get()
+
+            val imageAnalysis = ImageAnalysis.Builder()
+                .setOutputImageFormat(IMAGE_FORMAT_CAMERAX)
+                .setOutputImageRotationEnabled(true)
+                .apply { targetResolution?.let { setTargetResolution(it) } }
+                .build()
+                .apply { setAnalyzer(cameraExecutor, analyzer) }
+
+            cameraProvider.unbindAll() // Currently only binding image analysis
+            isAnalyzing = false
+
+            try {
+                cameraProvider.bindToLifecycle(activity, cameraSelector, imageAnalysis)
+                isAnalyzing = true
+            } catch (e: IllegalStateException) {
+                Log.e(TAG, "Camera binding failed", e)
+                callback(null)
+                return@addListener
+            } catch (e: IllegalArgumentException) {
+                Log.e(TAG, "Camera binding failed", e)
+                callback(null)
+                return@addListener
+            }
+
+            val realResolution = imageAnalysis.resolutionInfo?.run {
+                // No need to account for screenRotation here
+                if (rotationDegrees % ROTATION_SAVING_STEP == 0) resolution else resolution.flipped()
+            }
+            if (realResolution != targetResolution) {
+                Log.e(TAG, "Targeted $targetResolution, but got $realResolution instead.")
+            }
+
+            callback(realResolution)
+
+            Log.i(TAG, "Started image analysis on $realResolution.")
+        }, ContextCompat.getMainExecutor(activity))
+    }
+
+    fun stopImageAnalysis() {
+        if (!isAnalyzing) {
+            Log.i(TAG, "Image analysis already stopped.")
+            return
+        }
+
+        Log.i(TAG, "Stopping image analysis.")
+
+        ProcessCameraProvider.getInstance(activity).addListener({
+            cameraProviderFuture.get().unbindAll()  // Currently only binding image analysis
+            Log.i(TAG, "Stopped image analysis.")
+        }, ContextCompat.getMainExecutor(activity))
+    }
+
+    fun shutdown() {
+        cameraExecutor.shutdown()
+    }
+}

--- a/app/src/main/java/com/github/kpdandroid/utils/PreferencesManager.kt
+++ b/app/src/main/java/com/github/kpdandroid/utils/PreferencesManager.kt
@@ -2,6 +2,7 @@ package com.github.kpdandroid.utils
 
 import android.content.Context
 import android.util.Log
+import android.util.Size
 import androidx.core.content.edit
 
 private const val TAG = "PreferencesManager"
@@ -9,6 +10,9 @@ private const val PREFERENCES_FILE_NAME = "ALGORITHM_PREFERENCES"
 
 private const val ALGORITHM_KEY = "algorithm"
 private val ALGORITHM_DEFAULT = KeypointDetectionAlgorithm.NONE.formattedName
+
+private const val RESOLUTION_KEY = "resolution"
+private val RESOLUTION_DEFAULT = null
 
 class PreferencesManager(context: Context) {
     private val preferences = context.getSharedPreferences(
@@ -19,10 +23,17 @@ class PreferencesManager(context: Context) {
     var selectedAlgorithmName: String
         get() = preferences.getString(ALGORITHM_KEY, ALGORITHM_DEFAULT) ?: ALGORITHM_DEFAULT
         set(value) {
+            preferences.edit { putString(ALGORITHM_KEY, value) }
+            Log.i(TAG, "Algorithm $value has been selected.")
+        }
+
+    var selectedResolution: Size?
+        get() = preferences.getString(RESOLUTION_KEY, RESOLUTION_DEFAULT)
+            ?.let { Size.parseSize(it) }
+        set(value) {
             preferences.edit {
-                putString(ALGORITHM_KEY, value)
-                apply()
+                putString(RESOLUTION_KEY, value?.toString())
             }
-            Log.i(TAG, "$value algorithm was selected.")
+            Log.i(TAG, "Resolution ${value?.width} x ${value?.height} has been selected.")
         }
 }

--- a/app/src/main/java/com/github/kpdandroid/utils/PreferencesManager.kt
+++ b/app/src/main/java/com/github/kpdandroid/utils/PreferencesManager.kt
@@ -6,6 +6,7 @@ import android.util.Size
 import androidx.core.content.edit
 
 private const val TAG = "PreferencesManager"
+
 private const val PREFERENCES_FILE_NAME = "ALGORITHM_PREFERENCES"
 
 private const val ALGORITHM_KEY = "algorithm"
@@ -34,6 +35,6 @@ class PreferencesManager(context: Context) {
             preferences.edit {
                 putString(RESOLUTION_KEY, value?.toString())
             }
-            Log.i(TAG, "Resolution ${value?.width} x ${value?.height} has been selected.")
+            Log.i(TAG, "Resolution $value has been selected.")
         }
 }

--- a/app/src/main/java/com/github/kpdandroid/utils/SnapshotAnalyzer.kt
+++ b/app/src/main/java/com/github/kpdandroid/utils/SnapshotAnalyzer.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.geometry.Offset
 import com.github.kpdandroid.ui.SnapshotViewModel
 import java.nio.ByteBuffer
 
-private const val TAG = "PhotoAnalyzer"
+private const val TAG = "SnapshotAnalyzer"
 
 class SnapshotAnalyzer(private val snapshotViewModel: SnapshotViewModel) : ImageAnalysis.Analyzer {
     override fun analyze(image: ImageProxy) {
@@ -18,7 +18,7 @@ class SnapshotAnalyzer(private val snapshotViewModel: SnapshotViewModel) : Image
         Log.v(TAG, "Analyzing snapshot of size ${width}x$height.")
 
         val (keypoints, calcTimeMs) = runDetection(rgbaBytesToRgbBytes(snapshot), width, height)
-        Log.v(TAG, "Detected ${keypoints.size} in $calcTimeMs ms.")
+        Log.v(TAG, "Detected ${keypoints.size} keypoints in $calcTimeMs ms.")
 
         snapshotViewModel.provideSnapshot(
             snapshot = rgbaBytesToBitmap(snapshot, width, height),

--- a/app/src/main/java/com/github/kpdandroid/utils/SnapshotAnalyzer.kt
+++ b/app/src/main/java/com/github/kpdandroid/utils/SnapshotAnalyzer.kt
@@ -10,14 +10,15 @@ import java.nio.ByteBuffer
 
 private const val TAG = "PhotoAnalyzer"
 
-class PhotoAnalyzer(private val snapshotViewModel: SnapshotViewModel) : ImageAnalysis.Analyzer {
+class SnapshotAnalyzer(private val snapshotViewModel: SnapshotViewModel) : ImageAnalysis.Analyzer {
     override fun analyze(image: ImageProxy) {
         val width = image.width
         val height = image.height
         val snapshot = image.planes[0].buffer.toByteArray()
-        Log.v(TAG, "Analyzing snapshot of size $width x $height.")
+        Log.v(TAG, "Analyzing snapshot of size ${width}x$height.")
 
         val (keypoints, calcTimeMs) = runDetection(rgbaBytesToRgbBytes(snapshot), width, height)
+        Log.v(TAG, "Detected ${keypoints.size} in $calcTimeMs ms.")
 
         snapshotViewModel.provideSnapshot(
             snapshot = rgbaBytesToBitmap(snapshot, width, height),
@@ -41,8 +42,6 @@ class PhotoAnalyzer(private val snapshotViewModel: SnapshotViewModel) : ImageAna
             val startTime = SystemClock.elapsedRealtime()
             val (keypoints, _) = detector.detect(rgbSnapshot)
             val calcTimeMs = SystemClock.elapsedRealtime() - startTime
-
-            Log.v(TAG, "Detected ${keypoints.size} in $calcTimeMs ms.")
 
             keypoints.map { Offset(it.x, it.y) } to calcTimeMs
         } ?: (emptyList<Offset>() to 0L)


### PR DESCRIPTION
- Now app accounts for split screen when checking for camera permission
- Resolution picking is implemented

Supported resolutions are taken for `ImageFormat.YUV_420_888` with fallback to `ImageFormat.JPEG` if YUV is unsupported.

Currently when phone is rotated picked resolution may change because the previously picked one may be no longer supported (because it's been also rotated). It can be solved by remember display mode (landscape/portrait) and rotate the saved resolution if the mode's been changed.