### PR TITLE
Partially optimize OpenCV build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -72,7 +72,6 @@ jobs:
                     -D CMAKE_CXX_COMPILER="$NDK/$CXX_COMPILER_SUBPATH" \
                     -D ANDROID_ABI=$ABI \
                     -D BUILD_DIR_SUFFIX=$ABI \
-                    -D ADD_ANDROID_ABI_CHECK=ON \
                     -P BuildOpenCV.cmake
             else
               echo "OpenCV for $ABI already prepared"

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -33,7 +33,7 @@ jobs:
           key: ${{runner.os}}-native
 
       - name: Prepare OpenCV
-        run: cmake -P BuildOpenCV.cmake
+        run: cmake -D NEED_EXAMPLES=ON -P BuildOpenCV.cmake
 
       - name: Configure CMake
         run: |

--- a/lib/src/main/cpp/README.md
+++ b/lib/src/main/cpp/README.md
@@ -60,17 +60,18 @@ if you plan to build the project for some other platform, you might need to spec
 options in the form of `-D<variable>=<value>`:
 
 - `BUILD_DIR_SUFFIX` -- suffix to append to OpenCV build directory name (defaults to none)
+- `NEED_EXAMPLES` -- whether to include extra modules required to build examples, see *Usage examples* below (`ON` or
+  `OFF`, disabled by default)
 - `CMAKE_GENERATOR` -- a generator to use (for example, `Ninja`, defaults to system default)
-- `CMAKE_TOOLCHAIN_FILE` -- path to a CMake toolchain file (defaults to none)
+- `CMAKE_TOOLCHAIN_FILE` -- path to a CMake toolchain file (not set by default)
 - `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` -- C/C++ compiler to use (for example, `clang`
   /`clang++` or a path to a compiler, defaults to system default)
 - `ANDROID_ABI` -- if building for Android, for which ABI to build (should be one of
-  the [supported ABIs](https://developer.android.com/ndk/guides/abis), defaults to the ABI from the
-  selected toolchain if any)
+  the [supported ABIs](https://developer.android.com/ndk/guides/abis), not set by default)
 - `ADD_ANDROID_ABI_CHECK` -- whether to modify `OpenCVConfig-version.cmake` with an additional check
-  for Android ABI compatibility (`ON` or `OFF`, disabled by default)
+  for Android ABI compatibility (`ON` or `OFF`, enabled by default when `ANDROID_ABI` is set)
 - `ANDROID_ARM_NEON` -- if building for Android, whether to let OpenCV make use of Neon or not (`ON`
-  or `OFF`, disabled by default)
+  or `OFF`, enabled by default when `ANDROID_ABI` is set)
 
 The toolchain file specified can influence the other variables default values.
 
@@ -106,6 +107,9 @@ The interface will be placed in the corresponding subdirectory of `generated` di
 build.
 
 ## Usage examples
+
+**Note**: if you use `BuildOpenCV.cmake` to build OpenCV, `NEED_EXAMPLES` must be set to `ON` to be able to build these
+examples.
 
 Files in `examples` directory demonstrate how to use this project for depth estimation. Specify
 `-DBUILD_EXAMPLES=ON` to build them.

--- a/lib/src/main/cpp/external/opencv/CMakeLists.txt
+++ b/lib/src/main/cpp/external/opencv/CMakeLists.txt
@@ -17,7 +17,10 @@ if (ANDROID)
     foreach (OPENCV_BUILD_DIR ${OPENCV_BUILD_DIRS})
         message(STATUS "Manually considering OpenCV directory: ${OPENCV_BUILD_DIR}")
         set(OpenCV_DIR ${OPENCV_BUILD_DIR})
-        find_package(OpenCV ${OPENCV_VERSION} COMPONENTS ${OPENCV_PUBLIC_LIBRARIES} ${OPENCV_PRIVATE_LIBRARIES})
+        find_package(
+                OpenCV ${OPENCV_VERSION}
+                COMPONENTS ${OPENCV_PUBLIC_LIBRARIES} ${OPENCV_PRIVATE_LIBRARIES} ${OPENCV_EXAMPLES_LIBRARIES}
+        )
         if (OpenCV_FOUND)
             break()
         endif ()


### PR DESCRIPTION
Modifies `BuildOpenCV.cmake` in the following ways:
- Removes unused modules and dependencies
- Turns on NEON support and Android ABI check by default
- Enables additional optimizations (OpenVX, OpenCL)*

(*) In fact, all optimizations require further configurations and doesn't really do anything now (see #63).

New `BuildOpenCV.cmake` option `NEED_EXAMPLES` is added to build OpenCV so that in includes the parts required in our native examples.